### PR TITLE
Add Plausible goal tracking to homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -563,7 +563,8 @@
         }
       }
     </style>
-    <script defer data-domain="teenytiny.ai" src="https://plausible.io/js/script.js"></script>
+    <script defer data-domain="teenytiny.ai" src="https://plausible.io/js/script.tagged-events.js"></script>
+    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
   <body>
     <!-- Hero Section -->
@@ -965,7 +966,7 @@
     <footer>
       <div class="container">
         <div class="footer-content">
-          <a href="https://github.com/teenytinyai/teenytinyai/">GitHub</a> |
+          <a href="https://github.com/teenytinyai/teenytinyai/" onclick="plausible('Outbound: GitHub')">GitHub</a> |
           Built by <a href="https://x.com/joewalnes">@joewalnes</a
           ><span class="footer-break"
             ><br />for fun, not for world domination. Hopefully.</span
@@ -1012,6 +1013,7 @@
       function changeModel() {
         const select = document.getElementById("modelSelect");
         currentModel = select.value;
+        plausible("Model Switched", { props: { model: currentModel } });
 
         // Clear chat and conversation history
         const chatMessages = document.getElementById("chatMessages");
@@ -1039,6 +1041,14 @@
           chatMessages.scrollTop = chatMessages.scrollHeight;
 
           conversationHistory.push({ role: "user", content: userMessage });
+
+          // Track chat engagement
+          if (firstMessage) {
+            plausible("Chat Message Sent", { props: { model: currentModel } });
+          }
+          if (conversationHistory.filter(m => m.role === "user").length === 3) {
+            plausible("Chat Multi-Turn", { props: { model: currentModel } });
+          }
 
           // Clear input
           if (firstMessage) {
@@ -1117,6 +1127,7 @@
           content.style.justifyContent = "flex-start";
           content.style.textAlign = "left";
           content.innerHTML = `TEENYTINY_API_KEY=${apiKey}`;
+          plausible("API Key Generated");
         } catch (error) {
           content.innerHTML = "Error generating API key. Please try again.";
           console.error("API key generation failed:", error);
@@ -1353,6 +1364,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         const select = document.getElementById("languageSelect");
         const codeExample = document.getElementById("codeExample");
         codeExample.textContent = codeExamples[select.value];
+        plausible("Code Language Changed", { props: { language: select.value } });
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary

- Upgrades Plausible script to `tagged-events` extension and adds custom event tracking for key user conversions
- Tracks 6 goals: **API Key Generated**, **Chat Message Sent**, **Chat Multi-Turn** (3+ messages), **Model Switched**, **Code Language Changed**, **Outbound: GitHub**
- Includes custom props (model, language) for breakdown analysis in Plausible dashboard

## Setup required

After deploying, create matching goals in Plausible dashboard (Site Settings → Goals):
1. `API Key Generated` (primary conversion)
2. `Chat Message Sent` (with `model` custom prop)
3. `Chat Multi-Turn` (with `model` custom prop)
4. `Model Switched` (with `model` custom prop)
5. `Code Language Changed` (with `language` custom prop)
6. `Outbound: GitHub`

Suggested funnel: **Visitor → Chat Message Sent → API Key Generated**

## Test plan

- [ ] Verify Plausible script loads without errors in browser console
- [ ] Open chat demo, send a message, confirm `Chat Message Sent` fires in Plausible real-time view
- [ ] Send 3 messages, confirm `Chat Multi-Turn` fires
- [ ] Switch model dropdown, confirm `Model Switched` fires
- [ ] Generate API key, confirm `API Key Generated` fires
- [ ] Switch code language dropdown, confirm `Code Language Changed` fires
- [ ] Click GitHub footer link, confirm `Outbound: GitHub` fires

https://claude.ai/code/session_01NDraXFtaMkRh55Mw2G2CEV